### PR TITLE
Concept Task reward correction

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -383,7 +383,7 @@ The Meta % is an added commission that an Admin earns for processing a task clai
    </td>
    <td>Valid Specification
    </td>
-   <td>1 Dash
+   <td>0.5 Dash
    </td>
    <td>10%
    </td>


### PR DESCRIPTION
Relatively new to Dash Incubator, I've read these rules. I found a discrepancy in the prices. It states that the Concept Task reward is 1 Dash however talking to Ash about this, he confirmed that indeed it should be 0.5 Dash.

This PR is to change the Concept Task reward from "1 Dash" to "0.5 Dash".

![image](https://user-images.githubusercontent.com/81209723/112098002-99d27900-8bd3-11eb-81a8-6cbdc8717a1e.png)

![image](https://user-images.githubusercontent.com/81209723/112098038-ab1b8580-8bd3-11eb-964f-6e3a59eff858.png)

